### PR TITLE
 Change docker to Python 3 and Create CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Floor, Boston, MA 02110-1301, USA.
 
 # Use an official Python runtime as a base image (host debian:jessie)
-FROM python:2-slim
+FROM python:3-slim
 
 MAINTAINER pycoal developers <coal-capstone@googlegroups.com>
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ _test_suite = 'pycoal.tests'
 _url = 'https://github.com/capstone-coal/pycoal'
 _version = '0.5.2'
 _zip_safe = False
+_entry_points = {'console_scripts' : ['pycoal-mineral = pycoal.cli.mineral:main', 'pycoal-mining = pycoal.cli.mining:main', 'pycoal-environment = pycoal.cli.environment:main']}
 
 # Setup Metadata
 # --------------
@@ -79,4 +80,5 @@ setup(
     url=_url,
     version=_version,
     zip_safe=_zip_safe,
+    _entry_points = entry_points
 )


### PR DESCRIPTION
Let me know if this correctly addresses the [Docker to Python 3](https://github.com/capstone-coal/pycoal/issues/127) and [Create CLI](https://github.com/capstone-coal/pycoal/issues/126) issues