### PR TITLE
Fix pycoal path of the docker image at README.str

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Start up an image and attach to it
 	docker run -t -i -d --name coalcontainer capstonecoal/coal /bin/bash
 	docker attach --sig-proxy=false coalcontainer
 
-pycoal is located in ~/coal and is almost ready to run. You just need to grab some data.
+pycoal is located in /coal and is almost ready to run. You just need to grab some data.
 
 Tests
 -----


### PR DESCRIPTION
Simply fix the documentation to the right current path of the library inside the docker image.